### PR TITLE
ci(sigstore): add non-blocking advisory cosign verify-blob step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,51 @@ jobs:
       - name: Validate submissions
         run: PYTHONPATH=src python -m bakeoff_results.validate --scan --allow-empty submissions
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Advisory Sigstore bundle check (non-blocking)
+        continue-on-error: true
+        run: |
+          echo "============================================================"
+          echo "ADVISORY: cosign verify-blob check — NOT gating this job."
+          echo "Existing submissions carry stub signature.sigstore.json files"
+          echo "that are not real Sigstore bundles. Full enforcement is"
+          echo "deferred until the upstream submitting workflow stabilises."
+          echo "TODO: promote to a hard gate — see issue #23."
+          echo "============================================================"
+
+          found=0
+          while IFS= read -r bundle; do
+            found=$((found + 1))
+            signed_file="$(dirname "$bundle")/manifest.json"
+            echo ""
+            echo "Bundle: $bundle"
+            if [ ! -f "$signed_file" ]; then
+              echo "  SKIP: expected signed file not found at $signed_file"
+              continue
+            fi
+            echo "  Signed file: $signed_file"
+            echo "  Attempting cosign verify-blob (advisory, failures expected on stubs)..."
+            cosign verify-blob \
+              --bundle "$bundle" \
+              --certificate-identity-regexp ".*" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "$signed_file" 2>&1 \
+              && echo "  RESULT: PASS" \
+              || echo "  RESULT: FAIL (advisory — not blocking; stub bundle or missing real signature)"
+          done < <(find submissions -name "signature.sigstore.json")
+
+          if [ "$found" -eq 0 ]; then
+            echo "No signature.sigstore.json files found in submissions/ — nothing to verify."
+          else
+            echo ""
+            echo "Advisory check complete. $found bundle(s) examined. See above for per-bundle results."
+          fi
+          echo "============================================================"
+          echo "ADVISORY step done. Job continues regardless of outcome."
+          echo "============================================================"
+
       - name: Build static index
         run: PYTHONPATH=src python -m bakeoff_results.build_index --submissions submissions --site site
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ Future backlog only. Current work is tracked in GitHub Issues.
 
 ## Publication pipeline
 
-- [ ] Full Sigstore/Rekor verification of `signature.sigstore.json` in CI — currently structural presence only; needs `cosign verify-blob` wired in once the submitting workflow stabilises
+- [ ] Full Sigstore/Rekor verification of `signature.sigstore.json` in CI — advisory `cosign verify-blob` step now exists in the `verify` job (`continue-on-error: true`, refs [#23](https://github.com/Rethunk-AI/bakeoff-results/issues/23)); remaining work is promoting it to a hard gate once upstream Rethunk-AI/bakeoff emits real Sigstore bundles
 - [ ] Resolve GitHub Pages activation via Actions token — tracked in [#2](https://github.com/Rethunk-AI/bakeoff-results/issues/2)
 
 ## Leaderboard


### PR DESCRIPTION
## Summary

- Adds a sigstore/cosign-installer@v3 step and an advisory cosign verify-blob shell step to the verify job in .github/workflows/ci.yml.
- The step is marked continue-on-error: true and prominently banners itself as ADVISORY not gating.
- Existing submissions carry stub signature.sigstore.json files, not real Sigstore bundles; a hard gate would break every push to main and the Pages deploy. This advisory posture matches the repo documented deferred until submitting workflow stabilises stance.
- Updates TODO.md to reflect that the advisory step now exists and the remaining work is promoting it to a hard gate.

## Why non-blocking?

Real cosign verify-blob requires a complete Sigstore bundle. The current stub bundles fail verification by design. Enforcing a hard gate now would permanently break publish until all existing submissions are re-signed, a separate coordinated operation tracked in #23.

## Activation path (hard gate)

Once Rethunk-AI/bakeoff emits real Sigstore bundles from its package-results.yml workflow:

1. Remove continue-on-error: true from the advisory step.
2. Wire signers.yaml OIDC subjects and workflow references into the cosign identity flags.
3. Close #23.

## Test plan

- [ ] CI verify job passes (advisory step runs, may log FAIL per bundle, job continues).
- [ ] publish job is unaffected (advisory step is verify-only).
- [ ] actionlint clean (verified locally, no output).

Advances #23 (does not close - full enforcement pending real upstream Sigstore bundles).