### PR TITLE
feat(results): result-state + partial-score badges, failure reason, state/cohort filters

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -44,6 +44,14 @@
     .multi-panel label { display: flex; align-items: center; gap: 0.4rem; font-size: 0.85em; margin-bottom: 0.2rem; cursor: pointer; font-weight: normal; }
     .multi-panel input[type=checkbox] { width: auto; margin: 0; padding: 0; }
     .similar-badge { display: inline-block; font-size: 0.8em; color: #58a6ff; background: #ddf4ff; padding: 1px 6px; border-radius: 3px; }
+    .state-badge { display: inline-block; font-size: 0.72em; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; padding: 1px 6px; border-radius: 3px; margin-right: 0.4rem; vertical-align: middle; border: 1px solid transparent; }
+    .state-superseded { color: #57606a; background: #eaeef2; border-color: #d0d7de; }
+    .state-disputed { color: #9a6700; background: #fff8c5; border-color: #eac54f; }
+    .state-revoked { color: #cf222e; background: #ffebe9; border-color: #ff818266; }
+    .state-incomplete { color: #9a6700; background: #fff4e0; border-color: #f0c674; }
+    .state-failed { color: #cf222e; background: #ffebe9; border-color: #ff818266; }
+    .score-badge { display: inline-block; font-size: 0.72em; font-weight: 600; color: #1a7f37; background: #dafbe1; border: 1px solid #aceebb; padding: 1px 6px; border-radius: 3px; margin-right: 0.4rem; vertical-align: middle; }
+    .actions-menu-info { padding: 0.4rem 0.75rem; font-size: 0.8em; color: #57606a; max-width: 320px; white-space: normal; border-top: 1px solid #eee; }
     .toggle-btn { padding: 0.4rem 0.8rem; background: #f6f8fa; border: 1px solid #ddd; border-radius: 4px; cursor: pointer; font-size: 0.85em; }
     .toggle-btn:hover { background: #e8eaed; }
     .clear-all-btn { padding: 0.3rem 0.7rem; background: #f6f8fa; border: 1px solid #ddd; border-radius: 4px; cursor: pointer; font-size: 0.85em; }
@@ -80,7 +88,7 @@
 </head>
 <body>
   <h1>Rethunk Bakeoff Results</h1>
-  <p>Generated at 2026-05-28T04:10:30+00:00. This static index is backed by validated
+  <p>Generated at 2026-05-29T04:04:07+00:00. This static index is backed by validated
   result bundles and is private until publication is approved.</p>
   <div class="filter-bar" id="filter-bar-root">
     <div class="filter-bar-header">
@@ -122,6 +130,22 @@
             <button class="filter-add-btn" data-target="f-gpu" title="Add value (multi-select)">+</button>
           </div>
           <div class="multi-panel" id="mp-f-gpu"></div>
+        </div>
+        <div class="filter-group" data-filter-id="f-state">
+          <label for="f-state">Result State</label>
+          <div class="filter-group-controls">
+            <select id="f-state"><option value="">All</option></select>
+            <button class="filter-add-btn" data-target="f-state" title="Add value (multi-select)">+</button>
+          </div>
+          <div class="multi-panel" id="mp-f-state"></div>
+        </div>
+        <div class="filter-group" data-filter-id="f-cohort">
+          <label for="f-cohort" title="Only runs sharing judge mode + config hash are directly rank-comparable">Cohort</label>
+          <div class="filter-group-controls">
+            <select id="f-cohort"><option value="">All</option></select>
+            <button class="filter-add-btn" data-target="f-cohort" title="Add value (multi-select)">+</button>
+          </div>
+          <div class="multi-panel" id="mp-f-cohort"></div>
         </div>
       </div>
       <div class="filter-row">
@@ -199,9 +223,9 @@
       </tr>
     </thead>
     <tbody id="results">
-<tr class='data-row' data-model_family="Mixtral" data-architecture="unknown" data-quantization="Q4_K_M" data-context_length="32K" data-params_total="46.7B" data-hw_tier="GPU" data-hw_vram_mb="92160" data-hw_arch="AMD RDNA3/Strix Halo" data-config_hash=""><td>synth-mixtral-8x7b-amd-strix-20260519</td><td>2026-05-19T10:10:00Z</td><td></td><td>mistralai/Mixtral-8x7B-Instruct-v0.1</td><td>synthetic</td><td>Mixtral</td><td>unknown</td><td>46.7B</td><td>12.9B</td><td>32K</td><td>Q4_K_M</td><td class="similar-results-col" style="display:none"></td><td class='hw-col-td' style='display:none'>AMD Radeon 890M (Strix Halo iGPU) · 90 GB · PCI 1002:15bf</td><td class="actions-cell"></td></tr>
-<tr class='data-row' data-model_family="LLaMA" data-architecture="unknown" data-quantization="Q4_K_M" data-context_length="128K" data-params_total="8B" data-hw_tier="GPU" data-hw_vram_mb="24576" data-hw_arch="Ada Lovelace" data-config_hash=""><td>synth-llama31-8b-rtx4090-20260519</td><td>2026-05-19T10:05:00Z</td><td></td><td>meta-llama/Meta-Llama-3.1-8B-Instruct</td><td>synthetic</td><td>LLaMA</td><td>unknown</td><td>8B</td><td>—</td><td>128K</td><td>Q4_K_M</td><td class="similar-results-col" style="display:none"></td><td class='hw-col-td' style='display:none'>NVIDIA GeForce RTX 4090 · 24 GB · PCI 10de:2204</td><td class="actions-cell"></td></tr>
-<tr class='data-row' data-model_family="Phi" data-architecture="unknown" data-quantization="Q4_K_M" data-context_length="128K" data-params_total="3.8B" data-hw_tier="GPU" data-hw_vram_mb="92160" data-hw_arch="AMD RDNA3/Strix Halo" data-config_hash=""><td>synth-phi35-mini-amd-strix-20260519</td><td>2026-05-19T10:00:00Z</td><td></td><td>microsoft/Phi-3.5-mini-instruct</td><td>synthetic</td><td>Phi</td><td>unknown</td><td>3.8B</td><td>—</td><td>128K</td><td>Q4_K_M</td><td class="similar-results-col" style="display:none"></td><td class='hw-col-td' style='display:none'>AMD Radeon 890M (Strix Halo iGPU) · 90 GB · PCI 1002:15bf</td><td class="actions-cell"></td></tr>
+<tr class='data-row' data-model_family="Mixtral" data-architecture="unknown" data-quantization="Q4_K_M" data-context_length="32K" data-params_total="46.7B" data-hw_tier="GPU" data-hw_vram_mb="92160" data-hw_arch="AMD RDNA3/Strix Halo" data-config_hash="" data-state="" data-score="" data-cohort="synthetic"><td>synth-mixtral-8x7b-amd-strix-20260519</td><td>2026-05-19T10:10:00Z</td><td></td><td>mistralai/Mixtral-8x7B-Instruct-v0.1</td><td>synthetic</td><td>Mixtral</td><td>unknown</td><td>46.7B</td><td>12.9B</td><td>32K</td><td>Q4_K_M</td><td class="similar-results-col" style="display:none"></td><td class='hw-col-td' style='display:none'>AMD Radeon 890M (Strix Halo iGPU) · 90 GB · PCI 1002:15bf</td><td class="actions-cell"></td></tr>
+<tr class='data-row' data-model_family="LLaMA" data-architecture="unknown" data-quantization="Q4_K_M" data-context_length="128K" data-params_total="8B" data-hw_tier="GPU" data-hw_vram_mb="24576" data-hw_arch="Ada Lovelace" data-config_hash="" data-state="" data-score="" data-cohort="synthetic"><td>synth-llama31-8b-rtx4090-20260519</td><td>2026-05-19T10:05:00Z</td><td></td><td>meta-llama/Meta-Llama-3.1-8B-Instruct</td><td>synthetic</td><td>LLaMA</td><td>unknown</td><td>8B</td><td>—</td><td>128K</td><td>Q4_K_M</td><td class="similar-results-col" style="display:none"></td><td class='hw-col-td' style='display:none'>NVIDIA GeForce RTX 4090 · 24 GB · PCI 10de:2204</td><td class="actions-cell"></td></tr>
+<tr class='data-row' data-model_family="Phi" data-architecture="unknown" data-quantization="Q4_K_M" data-context_length="128K" data-params_total="3.8B" data-hw_tier="GPU" data-hw_vram_mb="92160" data-hw_arch="AMD RDNA3/Strix Halo" data-config_hash="" data-state="" data-score="" data-cohort="synthetic"><td>synth-phi35-mini-amd-strix-20260519</td><td>2026-05-19T10:00:00Z</td><td></td><td>microsoft/Phi-3.5-mini-instruct</td><td>synthetic</td><td>Phi</td><td>unknown</td><td>3.8B</td><td>—</td><td>128K</td><td>Q4_K_M</td><td class="similar-results-col" style="display:none"></td><td class='hw-col-td' style='display:none'>AMD Radeon 890M (Strix Halo iGPU) · 90 GB · PCI 1002:15bf</td><td class="actions-cell"></td></tr>
     </tbody>
   </table>
   <p id="no-results" style="display:none">No results match selected filters.</p>
@@ -327,7 +351,7 @@
     }
 
     // --- Multi-select filter state ---
-    const FILTER_IDS = ["f-family", "f-arch", "f-quant", "f-gpu"];
+    const FILTER_IDS = ["f-family", "f-arch", "f-quant", "f-gpu", "f-state", "f-cohort"];
     let filterMode = {};
     let filterValues = {};
     try {
@@ -457,6 +481,8 @@
     populateSelect("f-family", "model_family");
     populateSelect("f-arch", "architecture");
     populateSelect("f-quant", "quantization");
+    populateSelect("f-state", "state");
+    populateSelect("f-cohort", "cohort");
 
     function populateComputed(id, computeFn) {
       const sel = document.getElementById(id);
@@ -490,6 +516,8 @@
       if (id === "f-arch") return (row.dataset.architecture || "").toLowerCase();
       if (id === "f-quant") return (row.dataset.quantization || "").toLowerCase();
       if (id === "f-gpu") return (row.dataset.hw_arch || "").toLowerCase();
+      if (id === "f-state") return (row.dataset.state || "").toLowerCase();
+      if (id === "f-cohort") return (row.dataset.cohort || "").toLowerCase();
       return "";
     }
 
@@ -802,7 +830,9 @@
       "f-family": "Model Family",
       "f-arch": "Architecture",
       "f-quant": "Quantization",
-      "f-gpu": "GPU Architecture"
+      "f-gpu": "GPU Architecture",
+      "f-state": "Result State",
+      "f-cohort": "Cohort"
     };
 
     function renderChips() {

--- a/site/index.json
+++ b/site/index.json
@@ -3,8 +3,10 @@
     {
       "architecture": "unknown",
       "bundle_path": "submissions/bastion-synthetic/synth-mixtral-8x7b-amd-strix-20260519",
+      "cohort": "synthetic",
       "config_hash": null,
       "context_length": "32K",
+      "failure_reason": null,
       "hardware": {
         "device_name": "AMD Radeon 890M (Strix Halo iGPU)",
         "device_pci": "1002:15bf",
@@ -15,18 +17,23 @@
       "model_ids": [
         "mistralai/Mixtral-8x7B-Instruct-v0.1"
       ],
+      "outcome": null,
       "params_active": "12.9B",
       "params_total": "46.7B",
       "quantization": "Q4_K_M",
       "run_id": "synth-mixtral-8x7b-amd-strix-20260519",
+      "score": null,
       "signer": null,
+      "state": null,
       "timestamp": "2026-05-19T10:10:00Z"
     },
     {
       "architecture": "unknown",
       "bundle_path": "submissions/bastion-synthetic/synth-llama31-8b-rtx4090-20260519",
+      "cohort": "synthetic",
       "config_hash": null,
       "context_length": "128K",
+      "failure_reason": null,
       "hardware": {
         "device_name": "NVIDIA GeForce RTX 4090",
         "device_pci": "10de:2204",
@@ -37,18 +44,23 @@
       "model_ids": [
         "meta-llama/Meta-Llama-3.1-8B-Instruct"
       ],
+      "outcome": null,
       "params_active": null,
       "params_total": "8B",
       "quantization": "Q4_K_M",
       "run_id": "synth-llama31-8b-rtx4090-20260519",
+      "score": null,
       "signer": null,
+      "state": null,
       "timestamp": "2026-05-19T10:05:00Z"
     },
     {
       "architecture": "unknown",
       "bundle_path": "submissions/bastion-synthetic/synth-phi35-mini-amd-strix-20260519",
+      "cohort": "synthetic",
       "config_hash": null,
       "context_length": "128K",
+      "failure_reason": null,
       "hardware": {
         "device_name": "AMD Radeon 890M (Strix Halo iGPU)",
         "device_pci": "1002:15bf",
@@ -59,14 +71,17 @@
       "model_ids": [
         "microsoft/Phi-3.5-mini-instruct"
       ],
+      "outcome": null,
       "params_active": null,
       "params_total": "3.8B",
       "quantization": "Q4_K_M",
       "run_id": "synth-phi35-mini-amd-strix-20260519",
+      "score": null,
       "signer": null,
+      "state": null,
       "timestamp": "2026-05-19T10:00:00Z"
     }
   ],
-  "generated_at": "2026-05-28T04:10:30+00:00",
+  "generated_at": "2026-05-29T04:04:07+00:00",
   "schema_version": "bakeoff-results/v1"
 }

--- a/src/bakeoff_results/build_index.py
+++ b/src/bakeoff_results/build_index.py
@@ -154,9 +154,72 @@ def _hardware(result: dict[str, Any]) -> dict[str, Any] | str:
     return "unknown"
 
 
+# Result states recognized for badge rendering. The first three are the
+# governance-defined states (GOVERNANCE.md); `incomplete`/`failed` extend them
+# so non-finishing runs are first-class rather than invisible (refs #9, #21).
+VALID_STATES = ("superseded", "disputed", "revoked", "incomplete", "failed")
+
+
+def _state(result: dict[str, Any], manifest: dict[str, Any]) -> str | None:
+    """Result state for badge rendering. Read from result or manifest.
+
+    Returns a recognized lowercase state, or None when absent/unrecognized so
+    accepted runs render no badge (graceful degradation — most bundles today
+    carry no state field yet)."""
+    for source in (result, manifest):
+        value = source.get("state")
+        if isinstance(value, str) and value.strip().lower() in VALID_STATES:
+            return value.strip().lower()
+    return None
+
+
+def _outcome(result: dict[str, Any]) -> str | None:
+    """Run outcome (e.g. completed/incomplete/failed) when the harness emits it."""
+    value = result.get("outcome")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _failure_reason(result: dict[str, Any]) -> str | None:
+    """Why/how a run did not complete, when present. Display side of #9 — the
+    harness must emit this upstream (Rethunk-AI/bakeoff) before it is populated."""
+    for key in ("failure_reason", "failure", "error"):
+        value = result.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _score(result: dict[str, Any]) -> str | None:
+    """Relative/partial score so weak or non-finishing runs still rank (#9).
+
+    Accepts `score` or `partial_score` as number or string; normalized to a
+    short display string. None when absent."""
+    for key in ("score", "partial_score"):
+        value = result.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            return f"{value:g}"
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _cohort(entry: dict[str, Any]) -> str:
+    """Comparability signature: only runs sharing judge mode + config hash are
+    directly rank-comparable (#22). Empty when neither is known."""
+    parts = [
+        str(entry.get("judge_mode") or "").strip(),
+        str(entry.get("config_hash") or "").strip(),
+    ]
+    return "|".join(p for p in parts if p)
+
+
 def index_entry(bundle: ValidatedBundle) -> dict[str, Any]:
     result = bundle.result
-    return {
+    entry = {
         "run_id": result["run_id"],
         "timestamp": result["timestamp"],
         "signer": _signer(bundle.manifest),
@@ -175,8 +238,14 @@ def index_entry(bundle: ValidatedBundle) -> dict[str, Any]:
         or _nested_string(result, "config", "hash")
         or _nested_string(result, "config", "sha256"),
         "hardware": _hardware(result),
+        "state": _state(result, bundle.manifest),
+        "outcome": _outcome(result),
+        "failure_reason": _failure_reason(result),
+        "score": _score(result),
         "bundle_path": bundle.path.as_posix(),
     }
+    entry["cohort"] = _cohort(entry)
+    return entry
 
 
 def build_index(submissions_dir: Path | str, site_dir: Path | str) -> dict[str, Any]:
@@ -336,12 +405,30 @@ def render_html(payload: dict[str, Any]) -> str:
         hw = entry.get("hardware") or "unknown"
         hw_tier_val, hw_vram_mb = _hw_tier(hw)
 
+        state = entry.get("state") or ""
+        score = entry.get("score") or ""
+        failure_reason = entry.get("failure_reason") or ""
+        cohort = entry.get("cohort") or ""
+
         # Columns (no config_hash in main columns — moved to row detail)
         # Col indices: 0=Run ID, 1=Timestamp, 2=Signer, 3=Models, 4=Judge Mode,
         #              5=Model Family, 6=Architecture, 7=Params(total), 8=Params(active),
         #              9=Context Len, 10=Quantization, 11=Similar Results (hidden), 12=Hardware
+        # Run ID cell (col 0) carries inline state + score badges so non-finishing
+        # and graded runs are visible WITHOUT adding table columns (refs #9, #21).
+        badges = ""
+        if state:
+            badges += (
+                f'<span class="state-badge state-{html.escape(state, quote=True)}" '
+                f'title="Result state: {html.escape(state, quote=True)}">{html.escape(state)}</span>'
+            )
+        if score:
+            badges += (
+                f'<span class="score-badge" title="Relative score">'
+                f'{html.escape(str(score))}</span>'
+            )
+        run_id_cell = f"<td>{badges}{html.escape(str(entry.get('run_id') or ''))}</td>"
         plain_cells = [
-            entry.get("run_id"),
             entry.get("timestamp"),
             entry.get("signer") or "",
             model_ids,
@@ -353,20 +440,31 @@ def render_html(payload: dict[str, Any]) -> str:
             entry.get("context_length") or "unknown",
             entry.get("quantization") or "unknown",
         ]
-        cells_html = "".join(f"<td>{html.escape(str(cell))}</td>" for cell in plain_cells)
+        cells_html = run_id_cell + "".join(
+            f"<td>{html.escape(str(cell))}</td>" for cell in plain_cells
+        )
         # Similar Results column (hidden by default — JS will populate badge content)
         cells_html += '<td class="similar-results-col" style="display:none"></td>'
         cells_html += f"<td class='hw-col-td' style='display:none'>{_hw_cell_html(hw)}</td>"
 
-        # Config hash in per-row Actions menu (⋮ button)
+        # Per-row Actions menu (⋮): config hash copy + failure reason when present
         cfg_escaped = html.escape(config_hash, quote=True)
+        menu_items = ""
         if config_hash:
+            menu_items += (
+                f'<button class="actions-menu-item" data-copy="{cfg_escaped}">'
+                f'Copy config hash</button>'
+            )
+        if failure_reason:
+            menu_items += (
+                f'<div class="actions-menu-info" title="{html.escape(failure_reason, quote=True)}">'
+                f'Failure: {html.escape(failure_reason)}</div>'
+            )
+        if menu_items:
             actions_cell = (
                 f'<td class="actions-cell">'
                 f'<button class="actions-btn" title="Row actions">&#8942;</button>'
-                f'<div class="actions-menu">'
-                f'<button class="actions-menu-item" data-copy="{cfg_escaped}">Copy config hash</button>'
-                f'</div>'
+                f'<div class="actions-menu">{menu_items}</div>'
                 f'</td>'
             )
         else:
@@ -383,6 +481,9 @@ def render_html(payload: dict[str, Any]) -> str:
             "hw_vram_mb": str(hw_vram_mb),
             "hw_arch": _gpu_arch_family(hw),
             "config_hash": config_hash,
+            "state": state,
+            "score": score,
+            "cohort": cohort,
         }
         str_data = {k: str(v) for k, v in data.items()}
         attrs = " ".join(f'data-{k}="{html.escape(v, quote=True)}"' for k, v in str_data.items())
@@ -438,6 +539,14 @@ def render_html(payload: dict[str, Any]) -> str:
     .multi-panel label {{ display: flex; align-items: center; gap: 0.4rem; font-size: 0.85em; margin-bottom: 0.2rem; cursor: pointer; font-weight: normal; }}
     .multi-panel input[type=checkbox] {{ width: auto; margin: 0; padding: 0; }}
     .similar-badge {{ display: inline-block; font-size: 0.8em; color: #58a6ff; background: #ddf4ff; padding: 1px 6px; border-radius: 3px; }}
+    .state-badge {{ display: inline-block; font-size: 0.72em; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; padding: 1px 6px; border-radius: 3px; margin-right: 0.4rem; vertical-align: middle; border: 1px solid transparent; }}
+    .state-superseded {{ color: #57606a; background: #eaeef2; border-color: #d0d7de; }}
+    .state-disputed {{ color: #9a6700; background: #fff8c5; border-color: #eac54f; }}
+    .state-revoked {{ color: #cf222e; background: #ffebe9; border-color: #ff818266; }}
+    .state-incomplete {{ color: #9a6700; background: #fff4e0; border-color: #f0c674; }}
+    .state-failed {{ color: #cf222e; background: #ffebe9; border-color: #ff818266; }}
+    .score-badge {{ display: inline-block; font-size: 0.72em; font-weight: 600; color: #1a7f37; background: #dafbe1; border: 1px solid #aceebb; padding: 1px 6px; border-radius: 3px; margin-right: 0.4rem; vertical-align: middle; }}
+    .actions-menu-info {{ padding: 0.4rem 0.75rem; font-size: 0.8em; color: #57606a; max-width: 320px; white-space: normal; border-top: 1px solid #eee; }}
     .toggle-btn {{ padding: 0.4rem 0.8rem; background: #f6f8fa; border: 1px solid #ddd; border-radius: 4px; cursor: pointer; font-size: 0.85em; }}
     .toggle-btn:hover {{ background: #e8eaed; }}
     .clear-all-btn {{ padding: 0.3rem 0.7rem; background: #f6f8fa; border: 1px solid #ddd; border-radius: 4px; cursor: pointer; font-size: 0.85em; }}
@@ -516,6 +625,22 @@ def render_html(payload: dict[str, Any]) -> str:
             <button class="filter-add-btn" data-target="f-gpu" title="Add value (multi-select)">+</button>
           </div>
           <div class="multi-panel" id="mp-f-gpu"></div>
+        </div>
+        <div class="filter-group" data-filter-id="f-state">
+          <label for="f-state">Result State</label>
+          <div class="filter-group-controls">
+            <select id="f-state"><option value="">All</option></select>
+            <button class="filter-add-btn" data-target="f-state" title="Add value (multi-select)">+</button>
+          </div>
+          <div class="multi-panel" id="mp-f-state"></div>
+        </div>
+        <div class="filter-group" data-filter-id="f-cohort">
+          <label for="f-cohort" title="Only runs sharing judge mode + config hash are directly rank-comparable">Cohort</label>
+          <div class="filter-group-controls">
+            <select id="f-cohort"><option value="">All</option></select>
+            <button class="filter-add-btn" data-target="f-cohort" title="Add value (multi-select)">+</button>
+          </div>
+          <div class="multi-panel" id="mp-f-cohort"></div>
         </div>
       </div>
       <div class="filter-row">
@@ -719,7 +844,7 @@ def render_html(payload: dict[str, Any]) -> str:
     }}
 
     // --- Multi-select filter state ---
-    const FILTER_IDS = ["f-family", "f-arch", "f-quant", "f-gpu"];
+    const FILTER_IDS = ["f-family", "f-arch", "f-quant", "f-gpu", "f-state", "f-cohort"];
     let filterMode = {{}};
     let filterValues = {{}};
     try {{
@@ -849,6 +974,8 @@ def render_html(payload: dict[str, Any]) -> str:
     populateSelect("f-family", "model_family");
     populateSelect("f-arch", "architecture");
     populateSelect("f-quant", "quantization");
+    populateSelect("f-state", "state");
+    populateSelect("f-cohort", "cohort");
 
     function populateComputed(id, computeFn) {{
       const sel = document.getElementById(id);
@@ -882,6 +1009,8 @@ def render_html(payload: dict[str, Any]) -> str:
       if (id === "f-arch") return (row.dataset.architecture || "").toLowerCase();
       if (id === "f-quant") return (row.dataset.quantization || "").toLowerCase();
       if (id === "f-gpu") return (row.dataset.hw_arch || "").toLowerCase();
+      if (id === "f-state") return (row.dataset.state || "").toLowerCase();
+      if (id === "f-cohort") return (row.dataset.cohort || "").toLowerCase();
       return "";
     }}
 
@@ -1194,7 +1323,9 @@ def render_html(payload: dict[str, Any]) -> str:
       "f-family": "Model Family",
       "f-arch": "Architecture",
       "f-quant": "Quantization",
-      "f-gpu": "GPU Architecture"
+      "f-gpu": "GPU Architecture",
+      "f-state": "Result State",
+      "f-cohort": "Cohort"
     }};
 
     function renderChips() {{

--- a/tests/test_bundle_tools.py
+++ b/tests/test_bundle_tools.py
@@ -21,7 +21,12 @@ def digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def make_bundle(root: Path, *, include_required_result_fields: bool = True) -> Path:
+def make_bundle(
+    root: Path,
+    *,
+    include_required_result_fields: bool = True,
+    extra_result: dict | None = None,
+) -> Path:
     bundle = root / "publisher" / "run-001"
     bundle.mkdir(parents=True)
 
@@ -37,6 +42,8 @@ def make_bundle(root: Path, *, include_required_result_fields: bool = True) -> P
             "source_commit": "abc1234",
         }
         result["models"] = [{"id": "model-a"}, {"model_id": "model-b"}]
+    if extra_result:
+        result.update(extra_result)
 
     write_json(bundle / "result.json", result)
     (bundle / "summary.md").write_text("# Summary\n\nFixture result.\n", encoding="utf-8")
@@ -200,6 +207,53 @@ class IndexBuilderTests(unittest.TestCase):
             self.assertEqual(entry["model_ids"], ["m_a"])
             self.assertEqual(entry["judge_mode"], "pairwise_all")
             self.assertEqual(entry["config_hash"], "abc123")
+
+    def test_state_score_and_failure_render(self) -> None:
+        # A non-finishing/graded run: state, partial score, and failure reason
+        # are extracted and surfaced inline without adding table columns.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            make_bundle(
+                root / "submissions",
+                extra_result={
+                    "state": "Incomplete",  # case-insensitive
+                    "partial_score": 0.42,
+                    "failure_reason": "timeout after 600s",
+                },
+            )
+
+            payload = build_index(root / "submissions", root / "site")
+            entry = payload["entries"][0]
+
+            self.assertEqual(entry["state"], "incomplete")
+            self.assertEqual(entry["score"], "0.42")
+            self.assertEqual(entry["failure_reason"], "timeout after 600s")
+            # cohort = judge_mode|config_hash
+            self.assertEqual(entry["cohort"], "static-fixture|config-sha256")
+
+            html = (root / "site" / "index.html").read_text(encoding="utf-8")
+            self.assertIn("state-incomplete", html)
+            self.assertIn("score-badge", html)
+            self.assertIn("timeout after 600s", html)
+            self.assertIn('id="f-state"', html)
+            self.assertIn('id="f-cohort"', html)
+            # Column count unchanged — no Column Count Mismatch (cf. closed #20)
+            self.assertEqual(html.count('data-col-index="'), 13)
+
+    def test_no_state_renders_no_badge(self) -> None:
+        # Graceful degradation: bundles without the new fields render cleanly.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            make_bundle(root / "submissions")
+
+            payload = build_index(root / "submissions", root / "site")
+            entry = payload["entries"][0]
+
+            self.assertIsNone(entry["state"])
+            self.assertIsNone(entry["score"])
+            self.assertIsNone(entry["failure_reason"])
+            html = (root / "site" / "index.html").read_text(encoding="utf-8")
+            self.assertNotIn("state-badge state-", html)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Display-side delivery for several backlog items, implemented **without adding table columns** so it avoids the hardcoded column-index surface that produced the Column Count Mismatch in closed #20.

- **Result-state badges (#21)** — `superseded` / `disputed` / `revoked` plus extended `incomplete` / `failed`, rendered as an inline badge on the Run ID cell. New **Result State** filter dropdown.
- **Failure reason + partial scores (#24, display side of #9)** — partial/relative score renders as an inline badge; failure reason lands in the per-row Actions (⋮) menu. Lets weak / non-finishing models still appear and rank instead of being invisible.
- **Cohort filter (advances #22)** — `cohort = judge_mode|config_hash` exposed as a filter so users restrict to directly rank-comparable runs. The aggregate-ranking gate itself remains for when ranking UI exists.

## Design notes

- Inline **badges + data-attributes + filter dropdowns**, not new columns. The new filters reuse the existing generic filter machinery (same path as `f-gpu`), so `COL_COUNT` and every hardcoded column index are untouched.
- All new fields are **optional and degrade gracefully** — every current submission (no state/score/failure) renders exactly as before. Verified: synthetic bundles emit zero state badges.
- The data these surfaces display must be emitted **upstream by the harness** — downstream contract tracked in Rethunk-AI/bakeoff#23.

## Verification

- `python -m unittest` — 8 passed (6 prior + 2 new covering extraction, inline rendering, graceful no-field degradation, and a column-count-unchanged guard).
- `compileall` clean; `build_index` regenerates `site/` (3 entries).
- Generated inline `<script>` passes `node --check`.

Closes #21. Closes #24. Advances #9, #22.